### PR TITLE
feat: allow overriding OpenAI wire format

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -12,6 +12,7 @@ use crate::git_info::resolve_root_git_project_for_trust;
 use crate::model_family::ModelFamily;
 use crate::model_family::find_family_for_model;
 use crate::model_provider_info::ModelProviderInfo;
+use crate::model_provider_info::WireApi;
 use crate::model_provider_info::built_in_model_providers;
 use crate::openai_model_info::get_model_info;
 use crate::protocol::AskForApproval;
@@ -684,6 +685,15 @@ impl Config {
         for (key, provider) in cfg.model_providers.into_iter() {
             model_providers.entry(key).or_insert(provider);
         }
+
+        if let Ok(wire_format) = env::var("OPENAI_WIRE_FORMAT")
+            && let Some(provider) = model_providers.get_mut("openai") {
+                provider.wire_api = match wire_format.to_lowercase().as_str() {
+                    "chat" => WireApi::Chat,
+                    "responses" => WireApi::Responses,
+                    _ => provider.wire_api,
+                };
+            }
 
         let model_provider_id = model_provider
             .or(config_profile.model_provider)

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -256,7 +256,14 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
                     .filter(|v| !v.trim().is_empty()),
                 env_key: None,
                 env_key_instructions: None,
-                wire_api: WireApi::Responses,
+                wire_api: std::env::var("OPENAI_WIRE_FORMAT")
+                    .ok()
+                    .and_then(|v| match v.to_lowercase().as_str() {
+                        "chat" => Some(WireApi::Chat),
+                        "responses" => Some(WireApi::Responses),
+                        _ => None,
+                    })
+                    .unwrap_or(WireApi::Responses),
                 query_params: None,
                 http_headers: Some(
                     [("version".to_string(), env!("CARGO_PKG_VERSION").to_string())]
@@ -416,4 +423,5 @@ env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
         let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).unwrap();
         assert_eq!(expected_provider, provider);
     }
+
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -124,7 +124,7 @@ How long Codex will wait for activity on a streaming response before treating th
 
 ## model_provider
 
-Identifies which provider to use from the `model_providers` map. Defaults to `"openai"`. You can override the `base_url` for the built-in `openai` provider via the `OPENAI_BASE_URL` environment variable.
+Identifies which provider to use from the `model_providers` map. Defaults to `"openai"`. You can override the `base_url` for the built-in `openai` provider via the `OPENAI_BASE_URL` environment variable and the wire format via `OPENAI_WIRE_FORMAT` (`"responses"` or `"chat"`).
 
 Note that if you override `model_provider`, then you likely want to override
 `model`, as well. For example, if you are running ollama with Mistral locally,


### PR DESCRIPTION
## Summary
- allow overriding OpenAI wire format via `OPENAI_WIRE_FORMAT`
- document `OPENAI_WIRE_FORMAT` in configuration docs

## Testing
- `just fix -p codex-core`
- `USER=root RUST_TEST_THREADS=1 cargo test -p codex-core`
- `USER=root RUST_TEST_THREADS=1 cargo test --all-features` *(fails: building too slow to complete)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf8b5a1f88326ae74598e0d072504