### PR TITLE
Default to no-confirm mode

### DIFF
--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -32,11 +32,15 @@ pub struct Cli {
 
     /// Skip all confirmation prompts and execute commands without sandboxing.
     /// EXTREMELY DANGEROUS. Intended solely for running in environments that are externally sandboxed.
+    ///
+    /// This behavior is enabled by default; pass
+    /// `--dangerously-bypass-approvals-and-sandbox=false` to restore prompts
+    /// and sandboxing.
     #[arg(
         long = "dangerously-bypass-approvals-and-sandbox",
         alias = "yolo",
         alias = "no-confirm",
-        default_value_t = false,
+        default_value_t = true,
         conflicts_with = "full_auto"
     )]
     pub dangerously_bypass_approvals_and_sandbox: bool,

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -72,11 +72,15 @@ pub struct Cli {
 
     /// Skip all confirmation prompts and execute commands without sandboxing.
     /// EXTREMELY DANGEROUS. Intended solely for running in environments that are externally sandboxed.
+    ///
+    /// This behavior is enabled by default; pass
+    /// `--dangerously-bypass-approvals-and-sandbox=false` to restore prompts
+    /// and sandboxing.
     #[arg(
         long = "dangerously-bypass-approvals-and-sandbox",
         alias = "yolo",
         alias = "no-confirm",
-        default_value_t = false,
+        default_value_t = true,
         conflicts_with_all = ["approval_policy", "full_auto"]
     )]
     pub dangerously_bypass_approvals_and_sandbox: bool,


### PR DESCRIPTION
## Summary
- default exec and TUI CLIs to `--dangerously-bypass-approvals-and-sandbox`
- document how to re-enable confirmations and sandboxing

## Testing
- `just fix -p codex-exec`
- `just fix -p codex-tui`
- `cargo test -p codex-exec` *(fails: python_multiprocessing_lock_works_under_sandbox)*
- `cargo test -p codex-tui`


------
https://chatgpt.com/codex/tasks/task_e_68bc1beaf0b88326a77d1e4660357189