### PR TITLE
Propagate auth to chat completions

### DIFF
--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -15,6 +15,7 @@ use tokio::time::timeout;
 use tracing::debug;
 use tracing::trace;
 
+use crate::CodexAuth;
 use crate::ModelProviderInfo;
 use crate::client_common::Prompt;
 use crate::client_common::ResponseEvent;
@@ -34,6 +35,7 @@ pub(crate) async fn stream_chat_completions(
     model_family: &ModelFamily,
     client: &reqwest::Client,
     provider: &ModelProviderInfo,
+    auth: &Option<CodexAuth>,
 ) -> Result<ResponseStream> {
     // Build messages array
     let mut messages = Vec::<serde_json::Value>::new();
@@ -277,7 +279,7 @@ pub(crate) async fn stream_chat_completions(
 
     debug!(
         "POST to {}: {}",
-        provider.get_full_url(&None),
+        provider.get_full_url(auth),
         serde_json::to_string_pretty(&payload).unwrap_or_default()
     );
 
@@ -286,7 +288,7 @@ pub(crate) async fn stream_chat_completions(
     loop {
         attempt += 1;
 
-        let req_builder = provider.create_request_builder(client, &None).await?;
+        let req_builder = provider.create_request_builder(client, auth).await?;
 
         let res = req_builder
             .header(reqwest::header::ACCEPT, "text/event-stream")

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -110,12 +110,15 @@ impl ModelClient {
         match self.provider.wire_api {
             WireApi::Responses => self.stream_responses(prompt).await,
             WireApi::Chat => {
+                let auth = self.auth_manager.as_ref().and_then(|m| m.auth());
+
                 // Create the raw streaming connection first.
                 let response_stream = stream_chat_completions(
                     prompt,
                     &self.config.model_family,
                     &self.client,
                     &self.provider,
+                    &auth,
                 )
                 .await?;
 

--- a/codex-rs/core/tests/chat_completions_auth.rs
+++ b/codex-rs/core/tests/chat_completions_auth.rs
@@ -1,0 +1,126 @@
+use std::sync::Arc;
+
+use codex_core::AuthManager;
+use codex_core::ContentItem;
+use codex_core::ModelClient;
+use codex_core::ModelProviderInfo;
+use codex_core::Prompt;
+use codex_core::ResponseItem;
+use codex_core::WireApi;
+use codex_core::spawn::CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR;
+use codex_protocol::mcp_protocol::AuthMode;
+use core_test_support::load_default_config_for_test;
+use futures::StreamExt;
+use tempfile::TempDir;
+use uuid::Uuid;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::header_regex;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+
+fn network_disabled() -> bool {
+    std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn chat_includes_authorization_header_with_openai_api_key() {
+    if network_disabled() {
+        println!(
+            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
+        );
+        return;
+    }
+
+    let server = MockServer::start().await;
+
+    let template = ResponseTemplate::new(200)
+        .insert_header("content-type", "text/event-stream")
+        .set_body_raw(
+            "data: {\"choices\":[{\"delta\":{}}]}\n\ndata: [DONE]\n\n",
+            "text/event-stream",
+        );
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .and(header_regex("Authorization", r"Bearer sk-test-key"))
+        .respond_with(template)
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let prev = std::env::var("OPENAI_API_KEY").ok();
+    unsafe {
+        std::env::set_var("OPENAI_API_KEY", "sk-test-key");
+    }
+
+    let provider = ModelProviderInfo {
+        name: "mock".into(),
+        base_url: Some(format!("{}/v1", server.uri())),
+        env_key: None,
+        env_key_instructions: None,
+        wire_api: WireApi::Chat,
+        query_params: None,
+        http_headers: None,
+        env_http_headers: None,
+        request_max_retries: Some(0),
+        stream_max_retries: Some(0),
+        stream_idle_timeout_ms: Some(5_000),
+        requires_openai_auth: true,
+    };
+
+    let codex_home = TempDir::new().unwrap();
+    let mut config = load_default_config_for_test(&codex_home);
+    config.model_provider_id = provider.name.clone();
+    config.model_provider = provider.clone();
+    let effort = config.model_reasoning_effort;
+    let summary = config.model_reasoning_summary;
+    let originator = config.responses_originator_header.clone();
+    let config = Arc::new(config);
+
+    let auth_manager = Arc::new(AuthManager::new(
+        codex_home.path().to_path_buf(),
+        AuthMode::ApiKey,
+        originator,
+    ));
+
+    let client = ModelClient::new(
+        Arc::clone(&config),
+        Some(auth_manager),
+        provider,
+        effort,
+        summary,
+        Uuid::new_v4(),
+    );
+
+    let mut prompt = Prompt::default();
+    prompt.input = vec![ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: "hello".to_string(),
+        }],
+    }];
+
+    let mut stream = client.stream(&prompt).await.unwrap();
+    while let Some(event) = stream.next().await {
+        if let Err(e) = event {
+            panic!("stream event error: {e}");
+        }
+    }
+
+    let request = &server.received_requests().await.unwrap()[0];
+    let auth = request.headers.get("authorization").unwrap();
+    assert_eq!(auth.to_str().unwrap(), "Bearer sk-test-key");
+
+    if let Some(prev) = prev {
+        unsafe {
+            std::env::set_var("OPENAI_API_KEY", prev);
+        }
+    } else {
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- accept optional auth in chat completions API and forward to request builder
- pass auth from ModelClient to chat completions
- test that chat requests include Authorization when OPENAI_API_KEY is set

## Testing
- `just --verbose fix -p codex-core`
- `USER=tester cargo test -p codex-core`
- `USER=tester cargo test --all-features` *(fails: error running landlock, python multiprocessing lock fails)*


------
https://chatgpt.com/codex/tasks/task_e_68bc389771bc83269e8c805842bea04f