### PR TITLE
feat(config): allow inline API keys

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -785,6 +785,7 @@ mod tests {
         let provider = ModelProviderInfo {
             name: "test".to_string(),
             base_url: Some("https://test.com".to_string()),
+            api_key: None,
             env_key: Some("TEST_API_KEY".to_string()),
             env_key_instructions: None,
             wire_api: WireApi::Responses,
@@ -845,6 +846,7 @@ mod tests {
         let provider = ModelProviderInfo {
             name: "test".to_string(),
             base_url: Some("https://test.com".to_string()),
+            api_key: None,
             env_key: Some("TEST_API_KEY".to_string()),
             env_key_instructions: None,
             wire_api: WireApi::Responses,
@@ -879,6 +881,7 @@ mod tests {
         let provider = ModelProviderInfo {
             name: "test".to_string(),
             base_url: Some("https://test.com".to_string()),
+            api_key: None,
             env_key: Some("TEST_API_KEY".to_string()),
             env_key_instructions: None,
             wire_api: WireApi::Responses,
@@ -984,6 +987,7 @@ mod tests {
             let provider = ModelProviderInfo {
                 name: "test".to_string(),
                 base_url: Some("https://test.com".to_string()),
+                api_key: None,
                 env_key: Some("TEST_API_KEY".to_string()),
                 env_key_instructions: None,
                 wire_api: WireApi::Responses,

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -687,13 +687,14 @@ impl Config {
         }
 
         if let Ok(wire_format) = env::var("OPENAI_WIRE_FORMAT")
-            && let Some(provider) = model_providers.get_mut("openai") {
-                provider.wire_api = match wire_format.to_lowercase().as_str() {
-                    "chat" => WireApi::Chat,
-                    "responses" => WireApi::Responses,
-                    _ => provider.wire_api,
-                };
-            }
+            && let Some(provider) = model_providers.get_mut("openai")
+        {
+            provider.wire_api = match wire_format.to_lowercase().as_str() {
+                "chat" => WireApi::Chat,
+                "responses" => WireApi::Responses,
+                _ => provider.wire_api,
+            };
+        }
 
         let model_provider_id = model_provider
             .or(config_profile.model_provider)
@@ -1124,6 +1125,7 @@ model_verbosity = "high"
         let openai_chat_completions_provider = ModelProviderInfo {
             name: "OpenAI using Chat Completions".to_string(),
             base_url: Some("https://api.openai.com/v1".to_string()),
+            api_key: None,
             env_key: Some("OPENAI_API_KEY".to_string()),
             wire_api: crate::WireApi::Chat,
             env_key_instructions: None,

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -46,6 +46,9 @@ pub struct ModelProviderInfo {
     pub name: String,
     /// Base URL for the provider's OpenAI-compatible API.
     pub base_url: Option<String>,
+    /// API key used for this provider. If set and non-empty, this key will be
+    /// injected into the `Authorization: Bearer` header. Overrides `env_key`.
+    pub api_key: Option<String>,
     /// Environment variable that stores the user's API key for this provider.
     pub env_key: Option<String>,
 
@@ -182,9 +185,17 @@ impl ModelProviderInfo {
     }
 
     /// If `env_key` is Some, returns the API key for this provider if present
-    /// (and non-empty) in the environment. If `env_key` is required but
-    /// cannot be found, returns an error.
+    /// (and non-empty) either inline via `api_key` or in the environment via
+    /// `env_key`. If both are specified, `api_key` takes precedence. If `env_key`
+    /// is required but cannot be found, returns an error.
     pub fn api_key(&self) -> crate::error::Result<Option<String>> {
+        if let Some(key) = self.api_key.as_ref() {
+            if key.trim().is_empty() {
+                return Ok(None);
+            }
+            return Ok(Some(key.clone()));
+        }
+
         match &self.env_key {
             Some(env_key) => {
                 let env_value = std::env::var(env_key);
@@ -254,6 +265,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
                 base_url: std::env::var("OPENAI_BASE_URL")
                     .ok()
                     .filter(|v| !v.trim().is_empty()),
+                api_key: None,
                 env_key: None,
                 env_key_instructions: None,
                 wire_api: std::env::var("OPENAI_WIRE_FORMAT")
@@ -320,6 +332,7 @@ pub fn create_oss_provider_with_base_url(base_url: &str) -> ModelProviderInfo {
     ModelProviderInfo {
         name: "gpt-oss".into(),
         base_url: Some(base_url.into()),
+        api_key: None,
         env_key: None,
         env_key_instructions: None,
         wire_api: WireApi::Chat,
@@ -347,6 +360,7 @@ base_url = "http://localhost:11434/v1"
         let expected_provider = ModelProviderInfo {
             name: "Ollama".into(),
             base_url: Some("http://localhost:11434/v1".into()),
+            api_key: None,
             env_key: None,
             env_key_instructions: None,
             wire_api: WireApi::Chat,
@@ -374,6 +388,7 @@ query_params = { api-version = "2025-04-01-preview" }
         let expected_provider = ModelProviderInfo {
             name: "Azure".into(),
             base_url: Some("https://xxxxx.openai.azure.com/openai".into()),
+            api_key: None,
             env_key: Some("AZURE_OPENAI_API_KEY".into()),
             env_key_instructions: None,
             wire_api: WireApi::Chat,
@@ -404,6 +419,7 @@ env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
         let expected_provider = ModelProviderInfo {
             name: "Example".into(),
             base_url: Some("https://example.com".into()),
+            api_key: None,
             env_key: Some("API_KEY".into()),
             env_key_instructions: None,
             wire_api: WireApi::Chat,
@@ -423,5 +439,4 @@ env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
         let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).unwrap();
         assert_eq!(expected_provider, provider);
     }
-
 }

--- a/codex-rs/core/tests/chat_completions_auth.rs
+++ b/codex-rs/core/tests/chat_completions_auth.rs
@@ -58,6 +58,7 @@ async fn chat_includes_authorization_header_with_openai_api_key() {
     let provider = ModelProviderInfo {
         name: "mock".into(),
         base_url: Some(format!("{}/v1", server.uri())),
+        api_key: None,
         env_key: None,
         env_key_instructions: None,
         wire_api: WireApi::Chat,

--- a/codex-rs/core/tests/chat_completions_payload.rs
+++ b/codex-rs/core/tests/chat_completions_payload.rs
@@ -46,6 +46,7 @@ async fn run_request(input: Vec<ResponseItem>) -> Value {
     let provider = ModelProviderInfo {
         name: "mock".into(),
         base_url: Some(format!("{}/v1", server.uri())),
+        api_key: None,
         env_key: None,
         env_key_instructions: None,
         wire_api: WireApi::Chat,

--- a/codex-rs/core/tests/chat_completions_sse.rs
+++ b/codex-rs/core/tests/chat_completions_sse.rs
@@ -39,6 +39,7 @@ async fn run_stream(sse_body: &str) -> Vec<ResponseEvent> {
     let provider = ModelProviderInfo {
         name: "mock".into(),
         base_url: Some(format!("{}/v1", server.uri())),
+        api_key: None,
         env_key: None,
         env_key_instructions: None,
         wire_api: WireApi::Chat,

--- a/codex-rs/core/tests/model_provider_api_key.rs
+++ b/codex-rs/core/tests/model_provider_api_key.rs
@@ -1,0 +1,22 @@
+use codex_core::{ModelProviderInfo, WireApi};
+use pretty_assertions::assert_eq;
+
+#[test]
+fn inline_api_key_is_used() {
+    let provider = ModelProviderInfo {
+        name: "custom".into(),
+        base_url: Some("https://example.com".into()),
+        api_key: Some("secret".into()),
+        env_key: None,
+        env_key_instructions: None,
+        wire_api: WireApi::Chat,
+        query_params: None,
+        http_headers: None,
+        env_http_headers: None,
+        request_max_retries: None,
+        stream_max_retries: None,
+        stream_idle_timeout_ms: None,
+        requires_openai_auth: false,
+    };
+    assert_eq!(provider.api_key().unwrap().as_deref(), Some("secret"));
+}

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -746,6 +746,7 @@ async fn azure_overrides_assign_properties_used_for_responses_url() {
     let provider = ModelProviderInfo {
         name: "custom".to_string(),
         base_url: Some(format!("{}/openai", server.uri())),
+        api_key: None,
         // Reuse the existing environment variable to avoid using unsafe code
         env_key: Some(existing_env_var_with_random_value.to_string()),
         query_params: Some(std::collections::HashMap::from([(
@@ -822,6 +823,7 @@ async fn env_var_overrides_loaded_auth() {
     let provider = ModelProviderInfo {
         name: "custom".to_string(),
         base_url: Some(format!("{}/openai", server.uri())),
+        api_key: None,
         // Reuse the existing environment variable to avoid using unsafe code
         env_key: Some(existing_env_var_with_random_value.to_string()),
         query_params: Some(std::collections::HashMap::from([(

--- a/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs
+++ b/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs
@@ -71,6 +71,7 @@ async fn continue_after_stream_error() {
     let provider = ModelProviderInfo {
         name: "mock-openai".into(),
         base_url: Some(format!("{}/v1", server.uri())),
+        api_key: None,
         env_key: Some("PATH".into()),
         env_key_instructions: None,
         wire_api: WireApi::Responses,

--- a/codex-rs/core/tests/suite/stream_no_completed.rs
+++ b/codex-rs/core/tests/suite/stream_no_completed.rs
@@ -74,6 +74,7 @@ async fn retries_on_early_close() {
     let model_provider = ModelProviderInfo {
         name: "openai".into(),
         base_url: Some(format!("{}/v1", server.uri())),
+        api_key: None,
         // Environment variable that should exist in the test environment.
         // ModelClient will return an error if the environment variable for the
         // provider is not set.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -2,10 +2,17 @@
 
 ## Usage-based billing alternative: Use an OpenAI API key
 
-If you prefer to pay-as-you-go, you can still authenticate with your OpenAI API key by setting it as an environment variable:
+If you prefer to pay-as-you-go, you can still authenticate with your OpenAI API key. Either set it as an environment variable:
 
 ```shell
 export OPENAI_API_KEY="your-api-key-here"
+```
+
+or store it directly in your `~/.codex/config.toml`:
+
+```toml
+[model_providers.openai]
+api_key = "your-api-key-here"
 ```
 
 This key must, at minimum, have write access to the Responses API.

--- a/docs/config.md
+++ b/docs/config.md
@@ -38,9 +38,8 @@ name = "OpenAI using Chat Completions"
 # The path `/chat/completions` will be amended to this URL to make the POST
 # request for the chat completions.
 base_url = "https://api.openai.com/v1"
-# If `env_key` is set, identifies an environment variable that must be set when
-# using Codex with this provider. The value of the environment variable must be
-# non-empty and will be used in the `Bearer TOKEN` HTTP header for the POST request.
+# Provide the API key directly or reference an environment variable containing it.
+# api_key = "sk-..."
 env_key = "OPENAI_API_KEY"
 # Valid values for wire_api are "chat" and "responses". Defaults to "chat" if omitted.
 wire_api = "chat"
@@ -63,7 +62,7 @@ Or a third-party provider (using a distinct environment variable for the API key
 [model_providers.mistral]
 name = "Mistral"
 base_url = "https://api.mistral.ai/v1"
-env_key = "MISTRAL_API_KEY"
+env_key = "MISTRAL_API_KEY"  # or set `api_key = "sk-..."`
 ```
 
 Note that Azure requires `api-version` to be passed as a query parameter, so be sure to specify it as part of `query_params` when defining the Azure provider:
@@ -74,6 +73,7 @@ name = "Azure"
 # Make sure you set the appropriate subdomain for this URL.
 base_url = "https://YOUR_PROJECT_NAME.openai.azure.com/openai"
 env_key = "AZURE_OPENAI_API_KEY"  # Or "OPENAI_API_KEY", whichever you use.
+# api_key = "sk-..."
 query_params = { api-version = "2025-04-01-preview" }
 ```
 
@@ -103,6 +103,7 @@ Example:
 [model_providers.openai]
 name = "OpenAI"
 base_url = "https://api.openai.com/v1"
+# api_key = "sk-..."
 env_key = "OPENAI_API_KEY"
 # network tuning overrides (all optional; falls back to built‑in defaults)
 request_max_retries = 4            # retry failed HTTP requests
@@ -190,6 +191,7 @@ profile = "o3"
 [model_providers.openai-chat-completions]
 name = "OpenAI using Chat Completions"
 base_url = "https://api.openai.com/v1"
+# api_key = "sk-..."
 env_key = "OPENAI_API_KEY"
 wire_api = "chat"
 
@@ -576,6 +578,7 @@ Options that are specific to the TUI.
 | `mcp_servers.<id>.env` | map<string,string> | MCP server env vars. |
 | `model_providers.<id>.name` | string | Display name. |
 | `model_providers.<id>.base_url` | string | API base URL. |
+| `model_providers.<id>.api_key` | string | API key to send in Authorization header. |
 | `model_providers.<id>.env_key` | string | Env var for API key. |
 | `model_providers.<id>.wire_api` | `chat` \| `responses` | Protocol used (default: `chat`). |
 | `model_providers.<id>.query_params` | map<string,string> | Extra query params (e.g., Azure `api-version`). |


### PR DESCRIPTION
## Summary
- allow model providers to specify an `api_key` directly in config.toml
- document inline API key usage in configuration and authentication guides
- add regression test for inline API key support

## Testing
- `cargo test -p codex-core`
- `cargo test --all-features` *(fails: sandbox::python_multiprocessing_lock_works_under_sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68bc42ba62bc8326866c9933ed760329