### PR TITLE
feat: persist provider selection

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -411,6 +411,7 @@ pub async fn persist_model_selection(
     codex_home: &Path,
     active_profile: Option<&str>,
     model: &str,
+    model_provider: &str,
     effort: Option<ReasoningEffort>,
 ) -> anyhow::Result<()> {
     let config_path = codex_home.join(CONFIG_TOML_FILE);
@@ -429,12 +430,14 @@ pub async fn persist_model_selection(
     if let Some(profile_name) = active_profile {
         let profile_table = ensure_profile_table(&mut doc, profile_name)?;
         profile_table["model"] = toml_edit::value(model);
+        profile_table["model_provider"] = toml_edit::value(model_provider);
         if let Some(effort) = effort {
             profile_table["model_reasoning_effort"] = toml_edit::value(effort.to_string());
         }
     } else {
         let table = doc.as_table_mut();
         table["model"] = toml_edit::value(model);
+        table["model_provider"] = toml_edit::value(model_provider);
         if let Some(effort) = effort {
             table["model_reasoning_effort"] = toml_edit::value(effort.to_string());
         }
@@ -1168,6 +1171,7 @@ exclude_slash_tmp = true
             codex_home.path(),
             None,
             "gpt-5-high-new",
+            "openai",
             Some(ReasoningEffort::High),
         )
         .await?;
@@ -1177,6 +1181,7 @@ exclude_slash_tmp = true
         let parsed: ConfigToml = toml::from_str(&serialized)?;
 
         assert_eq!(parsed.model.as_deref(), Some("gpt-5-high-new"));
+        assert_eq!(parsed.model_provider.as_deref(), Some("openai"));
         assert_eq!(parsed.model_reasoning_effort, Some(ReasoningEffort::High));
 
         Ok(())
@@ -1203,6 +1208,7 @@ model = "gpt-4.1"
             codex_home.path(),
             None,
             "o4-mini",
+            "openai",
             Some(ReasoningEffort::High),
         )
         .await?;
@@ -1211,6 +1217,7 @@ model = "gpt-4.1"
         let parsed: ConfigToml = toml::from_str(&serialized)?;
 
         assert_eq!(parsed.model.as_deref(), Some("o4-mini"));
+        assert_eq!(parsed.model_provider.as_deref(), Some("openai"));
         assert_eq!(parsed.model_reasoning_effort, Some(ReasoningEffort::High));
         assert_eq!(
             parsed
@@ -1231,6 +1238,7 @@ model = "gpt-4.1"
             codex_home.path(),
             Some("dev"),
             "gpt-5-high-new",
+            "openai",
             Some(ReasoningEffort::Low),
         )
         .await?;
@@ -1244,6 +1252,7 @@ model = "gpt-4.1"
             .expect("profile should be created");
 
         assert_eq!(profile.model.as_deref(), Some("gpt-5-high-new"));
+        assert_eq!(profile.model_provider.as_deref(), Some("openai"));
         assert_eq!(profile.model_reasoning_effort, Some(ReasoningEffort::Low));
 
         Ok(())
@@ -1271,6 +1280,7 @@ model = "gpt-5"
             codex_home.path(),
             Some("dev"),
             "o4-high",
+            "openai",
             Some(ReasoningEffort::Medium),
         )
         .await?;
@@ -1283,6 +1293,7 @@ model = "gpt-5"
             .get("dev")
             .expect("dev profile should survive updates");
         assert_eq!(dev_profile.model.as_deref(), Some("o4-high"));
+        assert_eq!(dev_profile.model_provider.as_deref(), Some("openai"));
         assert_eq!(
             dev_profile.model_reasoning_effort,
             Some(ReasoningEffort::Medium)

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -310,7 +310,20 @@ impl App {
                 self.show_model_save_hint();
             }
             AppEvent::UpdateModelProvider(id) => {
-                self.chat_widget.set_model_provider(id);
+                self.chat_widget.set_model_provider(id.clone());
+                if let Some(provider) = self.config.model_providers.get(&id).cloned() {
+                    if let Some(m) = provider.default_model.clone() {
+                        self.config.model = m.clone();
+                        if let Some(family) = find_family_for_model(&m) {
+                            self.config.model_family = family;
+                        }
+                    }
+                    self.config.model_provider_id = id;
+                    self.config.model_provider = provider;
+                }
+                self.model_saved_to_profile = false;
+                self.model_saved_to_global = false;
+                self.show_provider_save_hint();
             }
             AppEvent::UpdateAskForApprovalPolicy(policy) => {
                 self.chat_widget.set_approval_policy(policy);
@@ -330,11 +343,24 @@ impl App {
         let model = self.config.model.clone();
         if self.active_profile.is_some() {
             self.chat_widget.add_info_message(format!(
-                "Model switched to {model}. Press Ctrl+S to save it for this profile, then press Ctrl+S again to set it as your global default."
+                "Model switched to {model}. Press Ctrl+S to save it for this profile, then press Ctrl+S again to set it as your global default.",
             ));
         } else {
             self.chat_widget.add_info_message(format!(
-                "Model switched to {model}. Press Ctrl+S to save it as your global default."
+                "Model switched to {model}. Press Ctrl+S to save it as your global default.",
+            ));
+        }
+    }
+
+    fn show_provider_save_hint(&mut self) {
+        let provider = self.config.model_provider.name.clone();
+        if self.active_profile.is_some() {
+            self.chat_widget.add_info_message(format!(
+                "Provider switched to {provider}. Press Ctrl+S to save it for this profile, then press Ctrl+S again to set it as your global default.",
+            ));
+        } else {
+            self.chat_widget.add_info_message(format!(
+                "Provider switched to {provider}. Press Ctrl+S to save it as your global default.",
             ));
         }
     }
@@ -359,53 +385,63 @@ impl App {
         };
 
         let model = self.config.model.clone();
+        let provider_id = self.config.model_provider_id.clone();
+        let provider_name = self.config.model_provider.name.clone();
         let effort = self.config.model_reasoning_effort;
         let codex_home = self.config.codex_home.clone();
 
         match scope {
             SaveScope::Profile(profile) => {
-                match persist_model_selection(&codex_home, Some(profile), &model, Some(effort))
-                    .await
+                match persist_model_selection(
+                    &codex_home,
+                    Some(profile),
+                    &model,
+                    &provider_id,
+                    Some(effort),
+                )
+                .await
                 {
                     Ok(()) => {
                         self.model_saved_to_profile = true;
                         self.chat_widget.add_info_message(format!(
-                            "Saved model {model} ({effort}) for profile `{profile}`. Press Ctrl+S again to make this your global default."
+                            "Saved provider {provider_name} and model {model} ({effort}) for profile `{profile}`. Press Ctrl+S again to make this your global default.",
                         ));
                     }
                     Err(err) => {
                         tracing::error!(
                             error = %err,
-                            "failed to persist model selection via shortcut"
+                            "failed to persist model selection via shortcut",
                         );
                         self.chat_widget.add_error_message(format!(
-                            "Failed to save model preference for profile `{profile}`: {err}"
+                            "Failed to save provider and model preference for profile `{profile}`: {err}",
                         ));
                     }
                 }
             }
             SaveScope::Global => {
-                match persist_model_selection(&codex_home, None, &model, Some(effort)).await {
+                match persist_model_selection(&codex_home, None, &model, &provider_id, Some(effort))
+                    .await
+                {
                     Ok(()) => {
                         self.model_saved_to_global = true;
                         self.chat_widget.add_info_message(format!(
-                            "Saved model {model} ({effort}) as your global default."
+                            "Saved provider {provider_name} and model {model} ({effort}) as your global default.",
                         ));
                     }
                     Err(err) => {
                         tracing::error!(
                             error = %err,
-                            "failed to persist global model selection via shortcut"
+                            "failed to persist global model selection via shortcut",
                         );
                         self.chat_widget.add_error_message(format!(
-                            "Failed to save global model preference: {err}"
+                            "Failed to save global provider and model preference: {err}",
                         ));
                     }
                 }
             }
             SaveScope::AlreadySaved => {
                 self.chat_widget.add_info_message(
-                    "Model preference already saved globally; no further action needed."
+                    "Provider and model preferences already saved globally; no further action needed."
                         .to_string(),
                 );
             }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -384,6 +384,7 @@ async fn run_ratatui_app(
                 &config.codex_home,
                 active_profile.as_deref(),
                 &config.model,
+                &config.model_provider_id,
                 None,
             )
             .await


### PR DESCRIPTION
## Summary
- save model provider when persisting model selection
- prompt to save provider and model with Ctrl+S
- pass provider when persisting from upgrade prompt

## Testing
- `just fmt`
- `just fix -p codex-core`
- `just fix -p codex-tui`
- `cargo test -p codex-core` *(fails: suite::client::prefers_apikey_when_config_prefers_apikey_even_with_chatgpt_tokens, suite::prompt_caching::overrides_turn_context_but_keeps_cached_prefix_and_key_constant, suite::prompt_caching::prefixes_context_and_instructions_once_and_consistently_across_requests)*
- `cargo test -p codex-tui`
- `cargo test --all-features` *(fails: suite::client::prefers_apikey_when_config_prefers_apikey_even_with_chatgpt_tokens, suite::prompt_caching::overrides_turn_context_but_keeps_cached_prefix_and_key_constant, suite::prompt_caching::prefixes_context_and_instructions_once_and_consistently_across_requests)*

------
https://chatgpt.com/codex/tasks/task_e_68c56243e2808326b16df65a8ded1e56