### PR TITLE
Use provider ID in environment context

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -370,6 +370,10 @@ impl ModelClient {
         self.provider.clone()
     }
 
+    pub fn get_provider_id(&self) -> String {
+        self.config.model_provider_id.clone()
+    }
+
     /// Returns the currently configured model slug.
     pub fn get_model(&self) -> String {
         self.config.model.clone()

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -693,7 +693,7 @@ impl Session {
             Some(turn_context.approval_policy),
             Some(turn_context.sandbox_policy.clone()),
             Some(self.user_shell.clone()),
-            Some(turn_context.client.get_provider().name),
+            Some(turn_context.client.get_provider_id()),
             Some(turn_context.client.get_model()),
         )));
         items


### PR DESCRIPTION
## Summary
- Pass model provider ID instead of display name when building the initial environment context
- Expose model provider ID via `ModelClient`

## Testing
- `cargo test -p codex-core --all-features`
- `cargo test --all-features` *(fails: suite::prompt_caching::overrides_turn_context_but_keeps_cached_prefix_and_key_constant, suite::client::prefers_apikey_when_config_prefers_apikey_even_with_chatgpt_tokens)*

------
https://chatgpt.com/codex/tasks/task_e_68c569a97cf0832686f15ec99b7f2357