### PR TITLE
Fix compilation errors in TUI and MCP server

### DIFF
--- a/codex-rs/mcp-server/src/codex_message_processor.rs
+++ b/codex-rs/mcp-server/src/codex_message_processor.rs
@@ -11,11 +11,16 @@ use codex_core::NewConversation;
 use codex_core::RolloutRecorder;
 use codex_core::SessionMeta;
 use codex_core::auth::CLIENT_ID;
+use codex_core::auth::get_auth_file;
 use codex_core::auth::login_with_api_key;
+use codex_core::auth::try_read_auth_json;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
 use codex_core::config::ConfigToml;
 use codex_core::config::load_config_as_toml;
+use codex_core::config_edit::CONFIG_KEY_EFFORT;
+use codex_core::config_edit::CONFIG_KEY_MODEL;
+use codex_core::config_edit::persist_non_null_overrides;
 use codex_core::default_client::get_codex_user_agent;
 use codex_core::exec::ExecParams;
 use codex_core::exec_env::create_env;
@@ -508,7 +513,7 @@ impl CodexMessageProcessor {
             (&[CONFIG_KEY_EFFORT], effort_str.as_deref()),
         ];
 
-        match persist_overrides_and_clear_if_none(
+        match persist_non_null_overrides(
             &self.config.codex_home,
             self.config.active_profile.as_deref(),
             &overrides,

--- a/codex-rs/mcp-server/src/outgoing_message.rs
+++ b/codex-rs/mcp-server/src/outgoing_message.rs
@@ -258,6 +258,7 @@ pub(crate) struct OutgoingError {
 mod tests {
     use codex_core::protocol::EventMsg;
     use codex_core::protocol::SessionConfiguredEvent;
+    use codex_core::protocol_config_types::ReasoningEffort;
     use codex_protocol::mcp_protocol::ConversationId;
     use codex_protocol::mcp_protocol::LoginChatGptCompleteNotification;
     use pretty_assertions::assert_eq;

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -340,6 +340,14 @@ impl App {
         self.chat_widget.token_usage()
     }
 
+    fn on_update_reasoning_effort(&mut self, effort: Option<ReasoningEffortConfig>) {
+        self.chat_widget.set_reasoning_effort(effort);
+        self.config.model_reasoning_effort = effort;
+        self.model_saved_to_profile = false;
+        self.model_saved_to_global = false;
+        self.show_model_save_hint();
+    }
+
     fn show_model_save_hint(&mut self) {
         let model = self.config.model.clone();
         if self.active_profile.is_some() {
@@ -389,6 +397,9 @@ impl App {
         let provider_id = self.config.model_provider_id.clone();
         let provider_name = self.config.model_provider.name.clone();
         let effort = self.config.model_reasoning_effort;
+        let effort_str = effort
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "none".to_string());
         let codex_home = self.config.codex_home.clone();
 
         match scope {
@@ -398,14 +409,14 @@ impl App {
                     Some(profile),
                     &model,
                     &provider_id,
-                    Some(effort),
+                    effort,
                 )
                 .await
                 {
                     Ok(()) => {
                         self.model_saved_to_profile = true;
                         self.chat_widget.add_info_message(format!(
-                            "Saved provider {provider_name} and model {model} ({effort}) for profile `{profile}`. Press Ctrl+S again to make this your global default.",
+                            "Saved provider {provider_name} and model {model} ({effort_str}) for profile `{profile}`. Press Ctrl+S again to make this your global default.",
                         ));
                     }
                     Err(err) => {
@@ -420,13 +431,12 @@ impl App {
                 }
             }
             SaveScope::Global => {
-                match persist_model_selection(&codex_home, None, &model, &provider_id, Some(effort))
-                    .await
+                match persist_model_selection(&codex_home, None, &model, &provider_id, effort).await
                 {
                     Ok(()) => {
                         self.model_saved_to_global = true;
                         self.chat_widget.add_info_message(format!(
-                            "Saved provider {provider_name} and model {model} ({effort}) as your global default.",
+                            "Saved provider {provider_name} and model {model} ({effort_str}) as your global default.",
                         ));
                     }
                     Err(err) => {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1208,11 +1208,7 @@ impl ChatWidget {
                     tx.send(AppEvent::UpdateModel(model_slug.clone()));
                     tx.send(AppEvent::UpdateReasoningEffort(effort));
                     tracing::info!(
-                        "New model: {}, New effort: {}, Current model: {}, Current effort: {}",
-                        model_slug.clone(),
-                        effort,
-                        current_model,
-                        current_effort
+                        "New model: {model_slug}, New effort: {effort:?}, Current model: {current_model}, Current effort: {current_effort:?}"
                     );
                 })];
                 items.push(SelectionItem {
@@ -1247,7 +1243,7 @@ impl ChatWidget {
                     ReasoningEffortConfig::High => "high",
                 };
                 let name = format!("{model_slug} {effort_label}");
-                let is_current = model_slug == current_model && effort == current_effort;
+                let is_current = model_slug == current_model && Some(effort) == current_effort;
                 let model_for_action = model_slug.clone();
                 let actions: Vec<SelectionAction> = vec![Box::new(move |tx| {
                     tx.send(AppEvent::CodexOp(Op::OverrideTurnContext {
@@ -1256,11 +1252,11 @@ impl ChatWidget {
                         sandbox_policy: None,
                         model_provider: None,
                         model: Some(model_for_action.clone()),
-                        effort: Some(effort),
+                        effort: Some(Some(effort)),
                         summary: None,
                     }));
                     tx.send(AppEvent::UpdateModel(model_for_action.clone()));
-                    tx.send(AppEvent::UpdateReasoningEffort(effort));
+                    tx.send(AppEvent::UpdateReasoningEffort(Some(effort)));
                 })];
                 items.push(SelectionItem {
                     name,


### PR DESCRIPTION
## Summary
- handle reasoning effort updates and normalize model persistence formatting
- ensure model selection popup uses optional reasoning effort correctly
- add missing imports and config persistence in MCP server tests

## Testing
- `just fmt`
- `just fix -p codex-tui`
- `just fix -p codex-mcp-server`
- `cargo test -p codex-tui`
- `cargo test -p codex-mcp-server` *(fails: 0 passed; 18 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c58bce54788326818f852aaed4f6a1